### PR TITLE
extract config loader

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,40 @@
+const config = require('pelias-config');
+const parser = require('./parser');
+
+// load the pelias config file and return a merged
+// object containing the blacklist data.
+function loader(){
+  
+  // check pelias-config for a list of blacklist files to load
+  const settings = config.generate();
+
+  // config does not contain the relevant properties
+  // return a no-op passthrough stream
+  if( !settings.imports || !settings.imports.blacklist ){
+    return {};
+  }
+
+  // config does not contain a valid list of files
+  // return a no-op passthrough stream
+  const bl = settings.imports.blacklist;
+  if( !Array.isArray( bl.files ) || bl.files.length === 0 ){
+    return {};
+  }
+
+  // load the blacklist files
+  // note: this throws an exception if a file is not found
+  const blacklists = bl.files.map( filename => parser( filename ) );
+
+  // merge all the blacklists togther
+  var merged = {};
+  blacklists.forEach( b => { for( var k in b ){ merged[k] = b[k]; } } );
+
+  // blacklist is empty, return a no-op passthrough stream
+  if( Object.keys( merged ).length === 0 ){
+    return {};
+  }
+
+  return merged;
+}
+
+module.exports = loader;

--- a/test/loader.js
+++ b/test/loader.js
@@ -1,0 +1,85 @@
+const fs = require('fs');
+const loader = require('../loader');
+
+module.exports.tests = {};
+
+module.exports.tests.loader = function(test, common) {
+
+  // pelias config missing imports property
+  test('pelias config missing imports property', function(t) {
+
+    // write a temporary config for testing
+    fs.writeFileSync('/tmp/tmp-pelias-config1.json', `{}`);
+    process.env.PELIAS_CONFIG = '/tmp/tmp-pelias-config1.json';
+
+    const blacklist = loader();
+    t.equals( Object.keys( blacklist ).length, 0 );
+    t.end();
+
+    // clean up
+    delete process.env.PELIAS_CONFIG;
+  });
+
+  // pelias config imports.blacklist.files property not an array
+  test('pelias config imports.blacklist.files property not an array', function(t) {
+
+    // write a temporary config for testing
+    fs.writeFileSync('/tmp/tmp-pelias-config2.json', `{ "imports": { "blacklist": { "files": "foo" } } }`);
+    process.env.PELIAS_CONFIG = '/tmp/tmp-pelias-config2.json';
+
+    const blacklist = loader();
+    t.equals( Object.keys( blacklist ).length, 0 );
+    t.end();
+
+    // clean up
+    delete process.env.PELIAS_CONFIG;
+  });
+
+  // pelias config imports.blacklist.files property empty
+  test('pelias config imports.blacklist.files property empty', function(t) {
+
+    // write a temporary config for testing
+    fs.writeFileSync('/tmp/tmp-pelias-config3.json', `{ "imports": { "blacklist": { "files": [] } } }`);
+    process.env.PELIAS_CONFIG = '/tmp/tmp-pelias-config3.json';
+
+    const blacklist = loader();
+    t.equals( Object.keys( blacklist ).length, 0 );
+    t.end();
+
+    // clean up
+    delete process.env.PELIAS_CONFIG;
+  });
+
+  // pelias config imports.blacklist.files contains valid files
+  test('pelias config imports.blacklist.files property empty', function(t) {
+
+    // write a temporary files for testing
+    fs.writeFileSync('/tmp/tmp-pelias-blacklist1', `source1:layer1:1`);
+    fs.writeFileSync('/tmp/tmp-pelias-blacklist2', `source2:layer2:2`);
+    fs.writeFileSync('/tmp/tmp-pelias-config4.json', `{
+      "imports": { "blacklist": { "files": [
+        "/tmp/tmp-pelias-blacklist1",
+        "/tmp/tmp-pelias-blacklist2"
+      ] }}
+    }`);
+    process.env.PELIAS_CONFIG = '/tmp/tmp-pelias-config4.json';
+
+    const blacklist = loader();
+    t.equals( Object.keys( blacklist ).length, 2 );
+    t.end();
+
+    // clean up
+    delete process.env.PELIAS_CONFIG;
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('loader: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/run.js
+++ b/test/run.js
@@ -23,6 +23,7 @@ const common = {
 const tests = [
   require('./parser.js'),
   require('./stream.js'),
+  require('./loader.js'),
   require('./index.js'),
 ];
 


### PR DESCRIPTION
extract config loader into separate file so it can be used independently of the stream
this allows the blacklist-stream to be used by modules which don't exclusively use streaming interfaces.

usage:

```js
const blacklist = require('pelias-blacklist-stream/loader')();
```